### PR TITLE
docs: add public ROADMAP.md (Claude for Open Source prep)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,99 @@
+# Roadmap
+
+> Public roadmap for `ai-business-skills` — 60 production-ready AI marketing skills for Claude Code, ChatGPT, Gemini & Copilot.
+> Last updated: 2026-05-12
+
+## 🎯 North Star
+Become the standard open-source AI marketing skill library for Vietnamese SMEs and global solo founders, with **150+ skills across 6+ regions** by end of 2026.
+
+---
+
+## ✅ Shipped
+
+### v2.5.0 — Global Marketing Cluster *(2026-05-08)*
+- 30 new global skills (US / EU / SEA / LATAM)
+- Dropshipping Mastery flagship skill
+- 5 agents upgraded to universal mode (VN + Global auto-routing)
+- 8 new global workflows
+- Multi-region docs (currency, tax, GDPR / CCPA / PDPA / LGPD)
+
+### v2.4.0 — Personal Brand + AI Avatar Cluster *(2026-05-08)*
+- 7 new personal-brand skills (founder / coach / creator)
+- AI Avatar production playbook (3-tier tools, 4 workflows)
+- Voice clone + podcast skill
+- 30-day Personal Brand Launch workflow
+
+### v2.3.0 — Quality Gates & Frameworks
+- 10 hard quality rules (`quality-gates-vn.md`)
+- 6 copy frameworks, 6 hook formulas (VN-specific)
+- MCP server integration guide
+- Agency client-onboarding workflow
+
+---
+
+## 🚧 In Progress *(Q2 2026)*
+
+### v2.6.0 — APAC Expansion *(target: 2026-06)*
+- [ ] Japan skill variants (JPY, cultural psychology, LINE/X platforms)
+- [ ] South Korea skill variants (KRW, KakaoTalk, Naver Blog, Coupang)
+- [ ] Taiwan skill variants (TWD, traditional Chinese, PChome)
+- [ ] APAC dropshipping addendum (Yahoo Auctions, Shopee TW)
+- [ ] APAC benchmark dataset
+
+### Infrastructure
+- [ ] Skill validator CI/CD enhancement (auto-eval on PR)
+- [ ] Multi-model regression tests (Claude / GPT / Gemini)
+- [ ] Coverage report for each skill
+
+---
+
+## 🗺️ Planned
+
+### v2.7.0 — India + MENA *(target: 2026-08)*
+- India cluster (INR, Hindi/English, WhatsApp Business, Flipkart, Meesho, GST)
+- MENA cluster (AED/SAR, Arabic-RTL support, Snapchat-heavy, Noon, Talabat)
+- VAT/Zakat compliance reference
+
+### v2.8.0 — B2B Cluster *(target: 2026-09)*
+- 10+ B2B-specific skills (ABM, LinkedIn outbound, demand gen, SQL/MQL handoff)
+- B2B export playbook for VN manufacturers
+- HubSpot/Salesforce CRM integration patterns
+
+### v3.0.0 — Vertical Packs *(target: 2026-Q4)*
+- SaaS pack (PLG, freemium, churn reduction)
+- E-commerce vertical packs (beauty, fashion, F&B, healthcare)
+- Local services pack (spa, clinic, F&B, education)
+
+---
+
+## 🌱 Long-term Vision *(2027+)*
+- Community-driven skill marketplace (verified contributors)
+- Multi-modal skills (image, audio, video as first-class outputs)
+- Real-time benchmark API (live Meta/TikTok/Google data per region)
+- Certified Skill Maintainer program for Vietnamese SMEs
+
+---
+
+## 🤝 How to Influence This Roadmap
+
+- 💡 **Request a skill:** Open an [Issue](https://github.com/minhnv0807/ai-business-skills/issues/new/choose) using the `Skill Request` template
+- 🐛 **Report a bug:** Use the `Bug Report` template
+- 🚀 **Contribute:** See [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- 💬 **Discuss:** [opa.business](https://opa.business)
+
+---
+
+## 📊 Velocity Snapshot
+
+| Quarter | Skills shipped | Releases | Notes |
+|---|---|---|---|
+| Q1 2026 | 22 (VN) | v2.0 → v2.3 | Foundation + quality gates |
+| Q2 2026 | 38 (VN + Global) | v2.4, v2.5 | Personal brand + 4 regions |
+| Q3 2026 (planned) | 25+ | v2.6, v2.7 | APAC + India/MENA |
+| Q4 2026 (planned) | 30+ | v2.8, v3.0 | B2B + vertical packs |
+
+**Target: 150+ skills by end of 2026.**
+
+---
+
+*This roadmap is a living document. Dates are targets, not commitments. Priorities adjust based on community feedback.*


### PR DESCRIPTION
## Summary
Add public ROADMAP.md to prepare repo for Claude for Open Source program application.

## Content
- **Shipped:** v2.3 (quality gates) → v2.4 (personal brand + AI avatar) → v2.5 (global cluster)
- **In progress:** v2.6 APAC (Japan/Korea/Taiwan) — Q2 2026
- **Planned:** v2.7 India+MENA → v2.8 B2B cluster → v3.0 vertical packs
- **North Star:** 150+ skills across 6+ regions by end of 2026
- **Long-term vision (2027+):** Community marketplace, multi-modal skills, real-time benchmark API

## Note on Tasks 2-3 (badge URLs)
Per the original request, Tasks 2-3 asked to fix `fullstack-mkt-skills` → `ai-business-skills` in README.md and README.vi.md badge URLs.

**Status:** Already complete from v3.0.0 rebuild (PR #15, commit 4070989 yesterday). Verified `grep "fullstack-mkt-skills" README.md README.vi.md` returns 0 matches.

## Test plan
- [x] ROADMAP.md syntax valid (99 lines, markdown)
- [x] All links resolve (`./CONTRIBUTING.md`, issues/new, opa.business)
- [x] No regressions to other files (single file added)