### PR TITLE
feat(skills): add 74-copy-hai-lop as additive dual-layer slogan lane

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://opa.business"
   },
   "metadata": {
-    "description": "Bo skill marketing toan dien cho AI agent — 143 skills (74 VN + 69 Global) — Role SOP Deep Integration bilingual: 4 role packs (Leader, Content, Designer, Performance) o CA HAI cluster + knowledge base nen tang + AI Marketing OS: Brand Hub, role-based agents/projects, skill chains, connectors/MCP, second brain, data loops, SOPs, review cadence. Chien luoc, noi dung, hieu suat, van hanh, personal brand, AI avatar, dropshipping, thiet ke, SaaS/growth, B2B sales pipeline. Thi truong Viet Nam 2025-2026 + Global (US/EU/SEA/LATAM). Anthropic-pattern aligned (.mcp.json + CONNECTORS.md)",
+    "description": "Bo skill marketing toan dien cho AI agent — 144 skills (75 VN + 69 Global) — Role SOP Deep Integration bilingual: 4 role packs (Leader, Content, Designer, Performance) o CA HAI cluster + knowledge base nen tang + AI Marketing OS: Brand Hub, role-based agents/projects, skill chains, connectors/MCP, second brain, data loops, SOPs, review cadence. Chien luoc, noi dung, hieu suat, van hanh, personal brand, AI avatar, dropshipping, thiet ke, SaaS/growth, B2B sales pipeline. Thi truong Viet Nam 2025-2026 + Global (US/EU/SEA/LATAM). Anthropic-pattern aligned (.mcp.json + CONNECTORS.md)",
     "version": "3.7.0",
     "repository": "https://github.com/minhnv0807/ai-business-skills"
   },
   "plugins": [
     {
       "name": "ai-business-skills",
-      "description": "143 skills marketing toan dien (74 VN + 69 Global) — tu lap ke hoach, brief chien dich, viet script TikTok, copy quang cao, den phan tich hieu suat, email marketing, personal brand strategy, AI avatar production, dropshipping mastery, design master, offer design, SEO/GEO growth, B2B lead generation, AI Marketing OS, va 4 role SOP packs (Leader 58-67, Content 35-40, Designer 41-50, Performance 51-57) day du o ca hai ngon ngu + knowledge base nen tang. Ho tro 4 regions (US/EU/SEA/LATAM) + VN. Tich hop voi Claude Code, Claude Pro, ChatGPT, Gemini, Copilot, Cursor. Dung foundation skills `product-marketing-context`, `22-personal-brand-context` (VN) va `product-marketing-context-global`, `22-personal-brand-context-global` (Global) de tranh lap lai thong tin.",
+      "description": "144 skills marketing toan dien (75 VN + 69 Global) — tu lap ke hoach, brief chien dich, viet script TikTok, copy quang cao, slogan hai lop, den phan tich hieu suat, email marketing, personal brand strategy, AI avatar production, dropshipping mastery, design master, offer design, SEO/GEO growth, B2B lead generation, AI Marketing OS, va 4 role SOP packs (Leader 58-67, Content 35-40, Designer 41-50, Performance 51-57) day du o ca hai ngon ngu + knowledge base nen tang. Ho tro 4 regions (US/EU/SEA/LATAM) + VN. Tich hop voi Claude Code, Claude Pro, ChatGPT, Gemini, Copilot, Cursor. Dung foundation skills `product-marketing-context`, `22-personal-brand-context` (VN) va `product-marketing-context-global`, `22-personal-brand-context-global` (Global) de tranh lap lai thong tin.",
       "source": ".",
       "strict": false,
       "skills": [
@@ -90,6 +90,7 @@
         "./skills/vi/70-lead-magnet",
         "./skills/vi/71-sales-enablement",
         "./skills/vi/72-hoi-dong-marketing",
+        "./skills/vi/74-copy-hai-lop",
         "./skills/en/product-marketing-context-global",
         "./skills/en/00-marketing-plan-global",
         "./skills/en/01-content-calendar-global",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-business-skills",
-  "description": "143 bilingual marketing skills (74 VN + 69 Global) for AI agents — strategy, content, performance, design production, leader ops, personal brand, and an AI Marketing OS. Vietnam 2025-2026 benchmarks plus US/EU/SEA/LATAM.",
+  "description": "144 bilingual marketing skills (75 VN + 69 Global) for AI agents — strategy, content, performance, design production, leader ops, personal brand, and an AI Marketing OS. Vietnam 2025-2026 benchmarks plus US/EU/SEA/LATAM.",
   "version": "3.7.0",
   "author": {
     "name": "Over Powers Agency",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `74-copy-hai-lop` — dual-layer slogan / poster line for the Vietnam cluster. Method adapted from the MIT skill [xiaoma-durex-copywriter](https://github.com/crawfordxx/xiaoma-durex-copywriter) (commit `d892bfb`): two semantic layers, one-hop leap, hook-before-formula, eight localized formulas, diction checklist, visual brief. **Does not replace** `05-copy-quang-cao` or `37-caption-social`. Durex / Reckitt posters, original corpus lines, brand-red default palette, and render scripts are not imported.
+
+### Changed
+
+- Sibling routing only on `05-copy-quang-cao` (2.5.2), `37-caption-social` (1.0.2), `42-brief-hinh-anh` (1.0.2), `58-positioning` (1.0.2). Paid-ads and organic-caption lanes stay the owners they were.
+- Marketplace skill count 143 → 144 (75 VN + 69 Global). Plugin version stays 3.7.0 until the next release cut.
+
 ## v3.7.0 — Routing, thresholds, and five new skills (2026-08-10)
 
 Came out of a structured comparison against another open marketing-skills repo. The comparison was less useful for what it suggested we add than for what it exposed in what we already had.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/v3.6.0-Bilingual%20Role%20SOP-6d28d9?style=for-the-badge&labelColor=1e1033" alt="v3.6.0"/>
-  <img src="https://img.shields.io/badge/Skills-143-6d28d9?style=for-the-badge&labelColor=1e1033" alt="143 Skills"/>
+  <img src="https://img.shields.io/badge/Skills-144-6d28d9?style=for-the-badge&labelColor=1e1033" alt="144 Skills"/>
   <img src="https://img.shields.io/badge/Agents-6-be185d?style=for-the-badge&labelColor=1e1033" alt="6 Agents"/>
   <img src="https://img.shields.io/badge/Workflows-19-0f766e?style=for-the-badge&labelColor=1e1033" alt="19 Workflows"/>
   <img src="https://img.shields.io/badge/Regions-VN%20%2B%20Global-f97316?style=for-the-badge&labelColor=1e1033" alt="VN + Global"/>
@@ -16,7 +16,7 @@
 <h1 align="center">ai-business-skills</h1>
 
 <p align="center">
-  <strong>Fullstack marketing skills cho AI agent — 143 skills bilingual (VN + Global).</strong>
+  <strong>Fullstack marketing skills cho AI agent — 144 skills bilingual (VN + Global).</strong>
   <br/>
   <sub>Vietnamese-first + Global (US/EU/SEA/LATAM) | Over Powers Agency</sub>
 </p>
@@ -104,7 +104,7 @@ flowchart TD
 ```bash
 git clone https://github.com/minhnv0807/ai-business-skills.git
 cd ai-business-skills
-bash install.sh --global   # 143 skills -> ~/.claude/skills/marketing/
+bash install.sh --global   # 144 skills -> ~/.claude/skills/marketing/
 ```
 
 Windows:
@@ -139,7 +139,7 @@ Test ngay trong Claude Code:
 
 ---
 
-## 📦 143 Skills (bilingual VN + Global)
+## 📦 144 Skills (bilingual VN + Global)
 
 > Mỗi skill = 1 file `SKILL.md` với frontmatter triggers + workflow body. AI agent tự kích hoạt skill khi user nhắc trigger keyword.
 
@@ -219,6 +219,8 @@ Bốn bộ SOP theo vai trò — mỗi bộ là quy trình vận hành đầy đ
 | **Performance ops (51-57)** | `51-audience-research` · `52-account-structure` · `53-tracking-setup` · `54-media-plan` · `55-scaling-ads` · `56-retargeting-plan` · `57-next-ads-plan` | Audience → media plan tính ngược từ doanh thu → tracking verify trước khi chạy → naming convention → scale winner → retarget theo tầng → plan kỳ sau |
 | **Leader ops (58-67)** | `58-positioning` · `59-go-to-market` · `60-launch-playbook` · `61-budget-planning` · `62-marketing-review` · `63-campaign-retrospective` · `64-team-brief` · `65-team-performance-review` · `66-crisis-playbook` · `67-agency-vendor-brief` | Positioning + GTM + launch → phân bổ ngân sách → gate duyệt output → retro → giao việc + đánh giá team → xử lý khủng hoảng → quản lý agency |
 
+**Creative copy (74)** — additive lane, không thay `05` / `37`: `74-copy-hai-lop` viết slogan / headline poster hai lớp nghĩa; ads trả tiền vẫn là `05`, caption organic vẫn là `37`.
+
 **Bilingual:** cả 4 pack đều có bản Global (`skills/en/35-67 *-global`) từ v3.6.0 — cùng framework và quy trình, nhưng USD benchmark, kênh toàn cầu (Klaviyo/Shopify/Meta US), và compliance FTC/GDPR/CCPA. Community seeding được viết lại theo chuẩn Reddit/Discord/Slack thay vì Facebook Group VN.
 
 **Kho kiến thức nền tảng:** [`knowledge/`](knowledge/) — 10 file tư duy (brandformance, blueprint 8 thành phần, phễu 6 bước, chiến lược kênh, Meta Ads framework, hệ thống KPI, customer insight, brand/offer architecture, AI Marketing OS, business model) + `knowledge/trien-khai/`. Dùng làm context upload cho AI project theo vai trò.
@@ -230,7 +232,7 @@ Bốn bộ SOP theo vai trò — mỗi bộ là quy trình vận hành đầy đ
 | Agent | Vai trò | Skills chính |
 |-------|---------|--------------|
 | [mkt-strategist](agents/mkt-strategist.md) | Chiến lược tổng + Leader strategy | 00, 02, 08, 09, 16, 17, 31-34, 58-61 (+ `-global` mirrors) |
-| [content-producer](agents/content-producer.md) | Sản xuất nội dung + content system | 01, 04, 05, 06, 35-40, 42-44 (+ `-global`) |
+| [content-producer](agents/content-producer.md) | Sản xuất nội dung + content system | 01, 04, 05, 06, 35-40, 42-44, 74 (+ `-global` trừ 74) |
 | [performance-analyst](agents/performance-analyst.md) | Phân tích hiệu suất + performance ops | 03, 07, 10, 13, 19, 21, 32, 34, 51-57 (+ `-global`) |
 | [channel-operator](agents/channel-operator.md) | Vận hành kênh + crisis | 11, 12, 14, 15, 18, 34, 49, 66 (+ `-global`) |
 | [design-producer](agents/design-producer.md) ⭐ | Visual & production | 12, 30, 41-50 |
@@ -243,7 +245,7 @@ Bốn bộ SOP theo vai trò — mỗi bộ là quy trình vận hành đầy đ
 - `client-onboard` (5-7 ngày, agency) — 20 → 09 → 08 → 10 → 00 → 02 → 01
 - `monthly-cycle` (3-5 ngày) — 13 → 03 → 07 → 10 → 01
 - `content-production` (weekly) — review calendar → 04 → film → 05 → schedule
-- `content-engine` ⭐ (vòng lặp tháng) — 35 → 09 → 01 → 36 → [37|04|05|38] → [42|43|44] → 39 → 07 → 40
+- `content-engine` ⭐ (vòng lặp tháng) — 35 → 09 → 01 → 36 → [37|04|05|74|38] → [42|43|44] → 39 → 07 → 40
 - `performance-loop` ⭐ (vòng lặp ads) — 51 → 10 → 54 → 53 → 52 → 19 → 21 → 55/56 → 07 → 57
 - `design-pipeline` ⭐ (T-14 → D+1) — 41 → [42|43|45] → 47 → 50
 - `leader-cadence` ⭐ (quý/campaign/tuần) — 00 → 61 → 02 → 64 → 62/47 → 07 → 63

--- a/README.vi.md
+++ b/README.vi.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/v3.6-Bilingual%20Role%20SOP-6d28d9?style=for-the-badge&labelColor=1e1033" alt="v3.6"/>
-  <img src="https://img.shields.io/badge/Skills-143-6d28d9?style=for-the-badge&labelColor=1e1033" alt="143 Skills"/>
+  <img src="https://img.shields.io/badge/Skills-144-6d28d9?style=for-the-badge&labelColor=1e1033" alt="144 Skills"/>
   <img src="https://img.shields.io/badge/Agents-6-be185d?style=for-the-badge&labelColor=1e1033" alt="6 Agents"/>
   <img src="https://img.shields.io/badge/Workflows-19-0f766e?style=for-the-badge&labelColor=1e1033" alt="19 Workflows"/>
   <img src="https://img.shields.io/badge/Market-Vietnam%202025--2026-f97316?style=for-the-badge&labelColor=1e1033" alt="Vietnam Market"/>
@@ -18,7 +18,7 @@
     <img src="https://img.shields.io/badge/%E2%98%95%20Moi%20Toi%20Mot%20Coffee-Ung%20ho%20Open%20Source-ff5e5b?style=for-the-badge" alt="Ung ho du an"/>
   </a>
   <br/>
-  <sub><b>💖 143 skills, 100% mien phi & MIT — neu giup ban tiet kiem thoi gian, hay ung ho tai <a href="https://www.opa.business/donate">opa.business/donate</a></b></sub>
+  <sub><b>💖 144 skills, 100% mien phi & MIT — neu giup ban tiet kiem thoi gian, hay ung ho tai <a href="https://www.opa.business/donate">opa.business/donate</a></b></sub>
 </p>
 
 > **🆕 v3.6.0 (2026-07-30)** — Role SOP Packs Go Global.
@@ -226,7 +226,7 @@ Copy file `.md` lam Custom Instructions hoac context. Moi file la 1 prompt doc l
 
 ---
 
-## 143 Skills (74 VN + 69 Global)
+## 144 Skills (75 VN + 69 Global)
 
 ### Cum VN — Marketing core + Personal Brand (36 skills: ★, 00-34)
 
@@ -531,6 +531,12 @@ Bon bo SOP theo vai tro. Moi skill la quy trinh van hanh day du: cac khau, input
 | 70 | [Lead Magnet](skills/vi/70-lead-magnet/SKILL.md) | Thiet ke cai mien phi doi lay thong tin lien he — truoc day khong skill nao so huu. Giao qua Zalo/Messenger truoc, xin so dien thoai thay vi email |
 | 71 | [Sales Enablement](skills/vi/71-sales-enablement/SKILL.md) | Tai lieu ban hang + pipeline gop 1 skill vi o SME VN cung mot nguoi lam ca hai. Co thu vien xu ly phan doi kieu VN va phuong an khong co CRM |
 | 72 | [Hoi Dong Marketing](skills/vi/72-hoi-dong-marketing/SKILL.md) | Nam archetype an danh, bat buoc co nguoi phan bien, san pham chinh la ban do bat dong. Chong kieu that bai pho bien nhat khi dung AI mot minh: AI dong y voi ban |
+
+**Copy sang tao (74)** — bo sung, khong thay `05` / `37`:
+
+| # | Skill | Lam gi |
+|---|-------|--------|
+| 74 | [Copy Hai Lop](skills/vi/74-copy-hai-lop/SKILL.md) | Slogan / headline poster hai lop nghia. Hoc co che (mot nhip, diem to la chet), viet cau moi cho brand VN. Ads tra tien van la 05; caption organic van la 37 |
 
 > **Kho kien thuc nen tang:** [`knowledge/`](knowledge/) — 10 file tu duy + `knowledge/trien-khai/`. Dung lam context upload cho AI project theo vai tro (Leader/Content/Designer/Performance). Kien truc 5 role project: skill [`34-ai-marketing-os`](skills/vi/34-ai-marketing-os/SKILL.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Public roadmap for `ai-business-skills` — 143 production-ready AI marketing skills for Claude Code, ChatGPT, Gemini & Copilot.
+> Public roadmap for `ai-business-skills` — 144 production-ready AI marketing skills for Claude Code, ChatGPT, Gemini & Copilot.
 > Last updated: 2026-08-10
 
 ## 🎯 North Star
@@ -115,7 +115,7 @@ Become the standard open-source AI marketing skill library for Vietnamese SMEs a
 | Q3 2026 | 78 (VN + Global) | v3.1 → v3.6 | Design master, growth, AI Marketing OS, role SOP packs bilingual |
 | Q4 2026 (planned) | 15+ | v3.7, v4.0 | APAC region variants, B2B vertical pack |
 
-**Current: 143 skills. Target: 150+ by end of 2026.**
+**Current: 144 skills. Target: 150+ by end of 2026.**
 
 ---
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,7 +12,7 @@
 | 02-brief-chien-dich | 2.1.0 | 2026-07-30 | strategy |
 | 03-danh-gia-hieu-suat | 2.3.1 | 2026-07-30 | performance |
 | 04-script-video | 2.3.0 | 2026-07-30 | content |
-| 05-copy-quang-cao | 2.4.1 | 2026-07-30 | content |
+| 05-copy-quang-cao | 2.5.2 | 2026-08-16 | content |
 | 06-brief-ugc-egc | 2.1.0 | 2026-07-30 | content |
 | 07-bao-cao-marketing | 2.1.1 | 2026-07-30 | performance |
 | 08-nghien-cuu-doi-thu | 2.3.1 | 2026-07-30 | strategy |
@@ -44,12 +44,12 @@
 | 34-ai-marketing-os | 1.1.0 | 2026-07-30 | operations |
 | 35-brand-voice | 1.0.0 | 2026-07-30 | content |
 | 36-content-brief | 1.0.0 | 2026-07-30 | content |
-| 37-caption-social | 1.0.0 | 2026-07-30 | content |
+| 37-caption-social | 1.0.2 | 2026-08-16 | content |
 | 38-seeding-plan | 1.0.0 | 2026-07-30 | content |
 | 39-content-audit | 1.0.0 | 2026-07-30 | content |
 | 40-next-content-plan | 1.0.0 | 2026-07-30 | content |
 | 41-campaign-asset-list | 1.0.0 | 2026-07-30 | operations |
-| 42-brief-hinh-anh | 1.0.0 | 2026-07-30 | content |
+| 42-brief-hinh-anh | 1.0.2 | 2026-08-16 | content |
 | 43-brief-carousel | 1.0.0 | 2026-07-30 | content |
 | 44-brief-video-editor | 1.0.0 | 2026-07-30 | content |
 | 45-brief-canva | 1.0.0 | 2026-07-30 | operations |
@@ -65,7 +65,7 @@
 | 55-scaling-ads | 1.0.0 | 2026-07-30 | performance |
 | 56-retargeting-plan | 1.0.0 | 2026-07-30 | performance |
 | 57-next-ads-plan | 1.0.0 | 2026-07-30 | performance |
-| 58-positioning | 1.0.0 | 2026-07-30 | strategy |
+| 58-positioning | 1.0.2 | 2026-08-16 | strategy |
 | 59-go-to-market | 1.0.0 | 2026-07-30 | strategy |
 | 60-launch-playbook | 1.0.0 | 2026-07-30 | strategy |
 | 61-budget-planning | 1.0.0 | 2026-07-30 | strategy |
@@ -80,6 +80,7 @@
 | 70-lead-magnet | 1.0.0 | 2026-08-10 | content |
 | 71-sales-enablement | 1.0.0 | 2026-08-10 | operations |
 | 72-hoi-dong-marketing | 1.0.0 | 2026-08-10 | strategy |
+| 74-copy-hai-lop | 1.0.0 | 2026-08-16 | content |
 | product-marketing-context-global | 1.0.0 | 2026-05-08 | foundation (global) |
 | 00-marketing-plan-global | 1.0.0 | 2026-05-08 | strategy (global) |
 | 01-content-calendar-global | 1.0.0 | 2026-05-08 | content (global) |
@@ -151,6 +152,14 @@
 | 67-agency-vendor-brief-global | 1.0.0 | 2026-07-30 | operations (global) |
 
 ## Changelog
+
+### 2026-08-16 — Unreleased (additive, no replace)
+
+**Added:** `74-copy-hai-lop` — dual-layer slogan / poster line for VN. Method adapted (not copied) from MIT skill xiaoma-durex-copywriter. Does not replace `05-copy-quang-cao` or `37-caption-social`. No Durex posters, corpus lines, or render scripts imported.
+
+**Changed:** sibling routing on `05-copy-quang-cao` 2.5.2, `37-caption-social` 1.0.2, `42-brief-hinh-anh` 1.0.2, `58-positioning` 1.0.2.
+
+**Marketplace:** 143 → 144 skills (75 VN + 69 Global). Plugin version stays 3.7.0 until release cut.
 
 ### 2026-08-10 — v3.7.0
 

--- a/agents/content-producer.md
+++ b/agents/content-producer.md
@@ -16,6 +16,7 @@ skills:
   - 42-brief-hinh-anh
   - 43-brief-carousel
   - 44-brief-video-editor
+  - 74-copy-hai-lop
 references:
   - content-angles
   - channel-system
@@ -29,7 +30,7 @@ Ban la **Content Producer** — chuyen gia san xuat noi dung marketing cho thi t
 
 - Xay brand voice document — nen tang giong dieu cho moi output content
 - Viet script video TikTok, Reels, YouTube Shorts
-- Viet caption social organic va copy quang cao Meta/TikTok Ads theo tung tang pheu
+- Viet caption social organic, copy quang cao Meta/TikTok Ads theo tung tang pheu, va slogan / headline poster hai lop (`74-copy-hai-lop`) — khong dung 05 de viet cau an y
 - Lap lich noi dung thang voi phan bo tru cot can doi + brief tung bai
 - Viet brief cho UGC creator, EGC nhan vien, KOC + brief visual (anh, carousel, video editor)
 - Seeding group/cong dong, audit content, lap plan ky sau tu data
@@ -121,6 +122,7 @@ Check `.agents/` directory:
 | Brand voice | 35-brand-voice | 35-brand-voice-global |
 | Content brief | 36-content-brief | 36-content-brief-global |
 | Organic caption | 37-caption-social | 37-social-caption-global |
+| Dual-layer slogan / poster | 74-copy-hai-lop | (chua co mirror Global) |
 | Community seeding | 38-seeding-plan | 38-community-seeding-global |
 | Content audit | 39-content-audit | 39-content-audit-global |
 | Next content plan | 40-next-content-plan | 40-next-content-plan-global |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,7 +31,7 @@ Cau truc va framework (AIDA, PAS, Quality Gates) la pho quat — dung duoc moi n
 
 ### Q: Co bao nhieu skill?
 
-**A:** 143 skills — 74 VN (`skills/vi/` + module personal branding) va 69 Global (`skills/en/` + module), kem 6 agents, 19 workflows, 8 reference files, va kho `knowledge/` (24 file kien thuc nen tang). Xem ban do day du tai `docs/skill-map.md`.
+**A:** 144 skills — 75 VN (`skills/vi/` + module personal branding) va 69 Global (`skills/en/` + module), kem 6 agents, 19 workflows, 8 reference files, va kho `knowledge/` (24 file kien thuc nen tang). Xem ban do day du tai `docs/skill-map.md`.
 
 ### Q: Skill 35-67 la gi, khac gi skill 00-34?
 

--- a/docs/skill-map.md
+++ b/docs/skill-map.md
@@ -111,7 +111,7 @@
 
 | Pack | Vong lap | Chain |
 |------|----------|-------|
-| Content system | Thang | 35 → 09 → 01 → 36 → [37\|04\|05\|38\|06\|14] → [42\|43\|44] → 39 → 07 → 40 → (lap lai 01) |
+| Content system | Thang | 35 → 09 → 01 → 36 → [37\|04\|05\|74\|38\|06\|14] → [42\|43\|44] → 39 → 07 → 40 → (lap lai 01) |
 | Design production | Theo campaign | 41 (T-14) → 45/12 concept (T-7) → 43/42 (T-5..T-1) → 47 review → 48 standby → 50 (D+1) |
 | Performance ops | Tuan / thang | 51 → 10 → 54 → 53 (verify) → 52 → 05 → 19 → 21 → 55/56 → 07 → 57 → (lap lai 54) |
 | Leader ops | Quy / campaign / tuan | 00 → 61 → 02 → 64 → 62/47 gate → 07 weekly → 63 retro → cap nhat Brand Hub (34) |
@@ -122,7 +122,7 @@
 
 ---
 
-## Bang tra nhanh — 143 Skills (74 VN + 69 Global)
+## Bang tra nhanh — 144 Skills (75 VN + 69 Global)
 
 | # | Skill | Lam gi | Khi nao dung | Output |
 |---|-------|--------|-------------|--------|
@@ -195,6 +195,7 @@
 | 65 | team-performance-review | Danh gia nhan su | Cuoi thang/quy | KPI scorecard + development plan |
 | 66 | crisis-playbook | Xu ly khung hoang | Khi co su co | Phan loai L1-L5 + response theo gio |
 | 67 | agency-vendor-brief | Brief + quan ly vendor | Thue agency/freelancer | SOW + milestone + danh gia vendor |
+| 74 | copy-hai-lop | Slogan / poster hai lop | Can cau ngan an y, khong phai ads | 3-5 the + brief visual |
 
 ---
 

--- a/skills/vi/05-copy-quang-cao/SKILL.md
+++ b/skills/vi/05-copy-quang-cao/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: 05-copy-quang-cao
-description: "Dung khi can viet copy quang cao TRA TIEN cho Meta, TikTok hoac Google — 6 bien the theo 3 tang pheu TOFU/MOFU/BOFU, tuan thu gioi han ky tu va chinh sach nen tang. Co Mode A cho san pham va Mode B cho personal brand, tu chon theo file context. Kich hoat khi user nhac 'viet copy quang cao', 'noi dung chay ads', 'copy Facebook Ads', 'copy TikTok Ads', 'google rsa', 'tieu de quang cao', 'copy retarget'. Khong dung cho — caption dang organic khong chay tien thi dung skill 37-caption-social; loi thoai video thi dung skill 04-script-video; duyet copy da viet thi dung skill 62-marketing-review."
+description: "Dung khi can viet copy quang cao TRA TIEN cho Meta, TikTok hoac Google — 6 bien the theo 3 tang pheu TOFU/MOFU/BOFU, tuan thu gioi han ky tu va chinh sach nen tang. Co Mode A cho san pham va Mode B cho personal brand, tu chon theo file context. Kich hoat khi user nhac 'viet copy quang cao', 'noi dung chay ads', 'copy Facebook Ads', 'copy TikTok Ads', 'google rsa', 'tieu de quang cao', 'copy retarget'. Khong dung cho — caption dang organic khong chay tien thi dung skill 37-caption-social; slogan / cau hai y / headline poster thi dung skill 74-copy-hai-lop; loi thoai video thi dung skill 04-script-video; duyet copy da viet thi dung skill 62-marketing-review."
 argument-hint: "<sản phẩm + key message + kênh>"
 metadata:
-  version: 2.5.1
+  version: 2.5.2
   category: content
 triggers:
   - "viet quang cao"
@@ -29,6 +29,7 @@ related:
   - 36-content-brief
   - 52-account-structure
   - 62-marketing-review
+  - 74-copy-hai-lop
   - references/copy-frameworks-vn
   - references/quality-gates-vn
   - references/hook-formulas-vn
@@ -356,6 +357,7 @@ Ket qua duyet ghi 1 trong 3: **DUYET** · **DUYET CO DIEU KIEN** (sua roi chay, 
 - **36-content-brief** — Brief dau vao cho nguoi viet copy (message, angle, proof point)
 - **52-account-structure** — Copy tang nao vao adset nao — kiem tra o Gate 3
 - **62-marketing-review** — Gate 2 duyet copy truoc khi len camp
+- **74-copy-hai-lop** — Slogan / poster / cau ngan hai lop; khong dung 05 de viet cau an y. Neu cau 74 phai chay ads, viet lai o day theo pheu + policy
 - **19-ab-test-setup** — Thiet ke test giua cac bien the copy sau khi launch
 
 ---

--- a/skills/vi/37-caption-social/SKILL.md
+++ b/skills/vi/37-caption-social/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: 37-caption-social
-description: "Dung khi can viet caption dang ORGANIC cho Facebook, Instagram, TikTok, Threads — khong chay tien, 2 bien the khac huong hook, kem hashtag va ghi chu chon ban. Kich hoat khi user nhac 'viet caption', 'caption Facebook', 'caption Instagram', 'noi dung dang bai', 'viet bai dang trang ca nhan', 'caption cho anh nay'. Khong dung cho — copy chay quang cao tra tien thi dung skill 05-copy-quang-cao; kich ban video thi dung skill 04-script-video; bai dang trong group cong dong thi dung skill 38-seeding-plan."
+description: "Dung khi can viet caption dang ORGANIC cho Facebook, Instagram, TikTok, Threads — khong chay tien, 2 bien the khac huong hook, kem hashtag va ghi chu chon ban. Kich hoat khi user nhac 'viet caption', 'caption Facebook', 'caption Instagram', 'noi dung dang bai', 'viet bai dang trang ca nhan', 'caption cho anh nay'. Khong dung cho — copy chay quang cao tra tien thi dung skill 05-copy-quang-cao; slogan / cau hai y / headline poster thi dung skill 74-copy-hai-lop; kich ban video thi dung skill 04-script-video; bai dang trong group cong dong thi dung skill 38-seeding-plan."
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   category: content
 license: MIT
 triggers:
@@ -21,6 +21,7 @@ related:
   - 36-content-brief
   - 01-lich-noi-dung
   - 05-copy-quang-cao
+  - 74-copy-hai-lop
   - 42-brief-hinh-anh
   - 43-brief-carousel
 ---
@@ -144,6 +145,7 @@ Ten file: `caption-social-[ten-bai]-[YYYYMMDD].md`
 - `36-content-brief`: nhan angle, insight goc, key message, CTA tu brief.
 - `01-lich-noi-dung`: caption viet theo slot trong lich (kenh, tang pheu, pillar).
 - `05-copy-quang-cao`: khi bai can chay ads (boost / camp) — viet lai theo chuan ads copy, khong dung nguyen caption organic.
+- `74-copy-hai-lop`: khi can cau ngan hai lop / slogan / headline poster; 37 chi dan cau do thanh caption dai neu can.
 - `42-brief-hinh-anh` / `43-brief-carousel`: brief visual di kem sau khi caption duyet.
 
 ## Checklist chat luong

--- a/skills/vi/42-brief-hinh-anh/SKILL.md
+++ b/skills/vi/42-brief-hinh-anh/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: 42-brief-hinh-anh
-description: "Dung khi can brief mot ANH TINH cho designer hoac photographer — banner, thumbnail, poster, anh feed: muc tieu visual, concept va mood, bo cuc, copy overlay, mau va font lay tu brand guideline, kich thuoc theo kenh, tieu chi duyet. Kich hoat khi user nhac 'brief anh', 'brief banner', 'brief thumbnail', 'brief visual', 'dat designer lam anh', 'ta lai anh muon lam sao', 'designer hoi lai hoai'. Khong dung cho — chuoi nhieu slide thi dung skill 43-brief-carousel; huong dan thao tac tren Canva thi dung skill 45-brief-canva; can asset gap trong ngay khi campaign dang chay thi dung skill 48-quick-visual-brief; tu gen anh bang AI thi dung skill 30-thiet-ke-master."
+description: "Dung khi can brief mot ANH TINH cho designer hoac photographer — banner, thumbnail, poster, anh feed: muc tieu visual, concept va mood, bo cuc, copy overlay, mau va font lay tu brand guideline, kich thuoc theo kenh, tieu chi duyet. Kich hoat khi user nhac 'brief anh', 'brief banner', 'brief thumbnail', 'brief visual', 'dat designer lam anh', 'ta lai anh muon lam sao', 'designer hoi lai hoai'. Khong dung cho — chua co cau overlay / slogan hai lop thi dung skill 74-copy-hai-lop truoc; chuoi nhieu slide thi dung skill 43-brief-carousel; huong dan thao tac tren Canva thi dung skill 45-brief-canva; can asset gap trong ngay khi campaign dang chay thi dung skill 48-quick-visual-brief; tu gen anh bang AI thi dung skill 30-thiet-ke-master."
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   category: content
 license: MIT
 triggers:
@@ -23,6 +23,7 @@ related:
   - 46-brand-guideline
   - 47-design-review
   - 30-thiet-ke-master
+  - 74-copy-hai-lop
 ---
 
 # Brief Hinh Anh
@@ -168,6 +169,7 @@ Deadline: [ngay] | Sua toi da: 2 lan
 - `45-brief-canva`: khi designer lam tren Canva, kem direction thao tac cu the.
 - `47-design-review`: review ket qua theo tieu chi cham diem sau khi designer nop.
 - `30-thiet-ke-master`: khi can gen anh bang AI thay vi designer lam tay.
+- `74-copy-hai-lop`: khi poster can cau hai lop / slogan — chot cau o 74 roi moi brief anh; 42 khong tu viet slogan.
 
 ## Checklist chat luong
 

--- a/skills/vi/58-positioning/SKILL.md
+++ b/skills/vi/58-positioning/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: 58-positioning
-description: "Dung khi can tra loi duoc tai sao khach chon MINH chu khong chon nguoi khac — positioning statement theo Promise + Proof + Path, ma tran khac biet so voi doi thu, category entry points, thap thong diep 3 tang va huong tagline. Kich hoat khi user nhac 'dinh vi thuong hieu', 'positioning', 'USP', 'khac biet voi doi thu', 'tai sao khach chon minh', 'tai dinh vi', 'noi gi de khach nho', 'san pham giong het thi truong'. Khong dung cho — soi doi thu dang lam gi thi dung skill 08-nghien-cuu-doi-thu; giong noi va tu vung khi viet thi dung skill 35-brand-voice; dong goi goi ban thi dung skill 31-offer-design; ke hoach ra mat san pham thi dung skill 59-go-to-market."
+description: "Dung khi can tra loi duoc tai sao khach chon MINH chu khong chon nguoi khac — positioning statement theo Promise + Proof + Path, ma tran khac biet so voi doi thu, category entry points, thap thong diep 3 tang va huong tagline. Kich hoat khi user nhac 'dinh vi thuong hieu', 'positioning', 'USP', 'khac biet voi doi thu', 'tai sao khach chon minh', 'tai dinh vi', 'noi gi de khach nho', 'san pham giong het thi truong'. Khong dung cho — soi doi thu dang lam gi thi dung skill 08-nghien-cuu-doi-thu; giong noi va tu vung khi viet thi dung skill 35-brand-voice; viet cau slogan / headline poster hai lop thi dung skill 74-copy-hai-lop; dong goi goi ban thi dung skill 31-offer-design; ke hoach ra mat san pham thi dung skill 59-go-to-market."
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   category: strategy
 license: MIT
 triggers:
@@ -23,6 +23,7 @@ related:
   - 59-go-to-market
   - 02-brief-chien-dich
   - 35-brand-voice
+  - 74-copy-hai-lop
 ---
 
 # Positioning — Dinh Vi San Pham / Thuong Hieu
@@ -190,6 +191,7 @@ Chon 2 truc phu hop nganh (gia x chat luong cam nhan; chuyen mon x gan gui; prem
 - `59-go-to-market`: dung positioning statement lam message goc cho GTM plan.
 - `02-brief-chien-dich`: core message trong brief lay tu message hierarchy Level 1.
 - `35-brand-voice`: tone of voice phai phan anh dinh vi.
+- `74-copy-hai-lop`: sau khi chot Promise, dung 74 de viet cau slogan / poster hai lop. 58 dung o huong tagline, khong thay 74 viet cau.
 
 ## Checklist chat luong
 

--- a/skills/vi/74-copy-hai-lop/SKILL.md
+++ b/skills/vi/74-copy-hai-lop/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: 74-copy-hai-lop
+description: "Dung khi can viet slogan, headline poster hoac cau ngan co HAI LOP NGHIA — mat chu dung o hot/le/canh, lop trong la brand, de nguoi doc tu nhay mot nhip. Ra 3-5 phuong an khac cong thuc, kem brief visual giao skill 42. Kich hoat khi user nhac 'viet slogan', 'cau hai y', 'copy poster', 'an y nhu Durex', 'headline poster', 'copy doi am', 'viet cau ngan dang anh'. Khong dung cho — copy quang cao tra tien theo pheu thi dung skill 05-copy-quang-cao; caption organic dai thi dung skill 37-caption-social; dinh vi chien luoc thi dung skill 58-positioning; brief anh chi tiet thi dung skill 42-brief-hinh-anh."
+metadata:
+  version: 1.0.0
+  category: content
+license: MIT
+triggers:
+  - "viet slogan"
+  - "cau hai y"
+  - "copy poster"
+  - "an y nhu Durex"
+  - "headline poster"
+  - "copy doi am"
+  - "viet cau ngan dang anh"
+  - "muon cau de nho"
+  - "copy le tet"
+  - "borrowed interest"
+output: "File .md — 3-5 the phuong an (cong thuc + cau ngan + lop mat/lop trong + chuoi nhay + brief visual), 1 the khuyen dung, checklist tu cham, va handoff sang 42/05/37"
+related:
+  - 05-copy-quang-cao
+  - 37-caption-social
+  - 35-brand-voice
+  - 36-content-brief
+  - 42-brief-hinh-anh
+  - 58-positioning
+  - 16-marketing-psychology
+  - 66-crisis-playbook
+  - 62-marketing-review
+---
+
+# Copy Hai Lop — Slogan / Poster / Cau Ngan De Nho
+
+> Skill nay **bo sung**, khong thay the `05-copy-quang-cao` hay `37-caption-social`.
+> 05 so huu copy tra tien, gioi han ky tu, chinh sach nen tang, 6 bien the pheu.
+> 37 so huu caption organic dai.
+> 74 so huu cau ngan hai lop + brief poster. Khong tron lane.
+
+Co che chuyen giao (khong phai "hoc noi dirty"): mot cau **dong thoi dung o hai ngu canh**. Tac gia chi viet lop mat. Nguoi doc tu nhay mot nhip sang lop trong. Nhip nhay do la ly do ho dung lai / chia se.
+
+Nguon method (MIT, khong nhap poster hay cau goc thuong hieu nuoc ngoai): xem `references/bien-gioi-va-nguon.md`.
+
+## Thu thap thong tin
+
+Mac dinh **giao the phuong an**, khong hoi khao sat. Chi hoi khi that su thieu.
+
+1. **Ban gi, cho ai?** Day la slot duy nhat duoc phep chan truoc khi viet. Neu khong suy ra duoc lop trong thi hoi 1 cau, roi dung.
+2. Neu user da noi ro san pham / dip / kenh: **khong hoi them**. Viet gia dinh thanh 1 dong ("Toi lam theo 'dang anh feed, khach cuoi tuan' — sai thi noi, toi doi").
+3. Khong bia them slot ngan sach, KPI, doi thu, brand color. Can thi gia dinh hoac ghi o cuoi "ban co the bo sung".
+4. Neu ngay le / so lieu user dua lech thuc te, ghi 1 cau canh bao trong output — khong dung flow.
+
+Toi da 4 cau neu that su thieu. Uu tien 1 cau hoac 0.
+
+## Nguyen tac
+
+1. **Hai lop, mot nhip.** Lop mat doc duoc ma khong can biet brand. Lop trong la gia tri san pham, khong phai tro cuoi rieng. Chuoi lien tuong chi duoc **mot mui ten**. Hai mui ten tro len = do, viet lai.
+2. **Diem to la chet.** Viet xong cau la dung. Khong them "y la...", "day chinh la suc manh cua...".
+3. **Cong thuc la cach viet, khong phai cach nghi.** Truoc khi chon cong thuc, tim moc noi (`references/tim-moc-noi.md`). Khong bam thi **bo dip**, dung gắng.
+4. **3-5 the phai khac that.** Khac cong thuc, khac chu the hinh, khac giong. Khong giao 3 bien the cua cung mot y.
+5. **Cau tren poster <= 12 chu.** Tot nhat 4-8. Dai hon chi khi la cap doi / song song. Caption dai de o phan phu, khong len hinh.
+6. **Roi vao "ban", khong vao thong so.** Nguoi ta chia se vi "cau nay noi minh", khong vi "san pham tot".
+7. **Doc brand voice truoc.** `35-brand-voice` + context san pham. Cau hay ma lech person brand = bo.
+8. **Khong dung skill nay de chay ads.** Neu user muon len camp, lay cau thang roi dua `05-copy-quang-cao` viet lai theo pheu + policy.
+
+## Khi nao KHONG dung
+
+| Tinh huong | Chuyen sang |
+|------------|-------------|
+| Copy Meta/TikTok/Google Ads, 6 bien the, 125 ky tu | `05-copy-quang-cao` |
+| Caption organic 3 doan, hashtag | `37-caption-social` |
+| Promise + proof + huong tagline chien luoc | `58-positioning` (74 chi viet cau sau khi da chot huong) |
+| Brief designer day du (size, safe zone, brand hex) | Viet cau o day xong giao `42-brief-hinh-anh` |
+| Khung hoang, xin loi, recall | `66-crisis-playbook` — chi duoc dung cong thuc Giu minh |
+| Y te, tai chinh, phap ly, thuoc, thuc pham chuc nang can claim | Khong choi hai nghia. Ve `05` + `62` neu van phai viet ads |
+| B2B mua so luong, hoi dong mua hang | Hai lop it khi lay duoc quyet dinh. Dung `71` / `33` |
+
+## Quy trinh
+
+### Buoc 0 — 4 slot, gia dinh het muc
+
+| Slot | Thieu thi |
+|------|-----------|
+| Ban gi | Hoi 1 cau. Khong doan. |
+| Noi voi ai | Lay persona nganh dien hinh, ghi gia dinh |
+| Co dip khong | Khong co → di huong insight san pham, khong bia hot |
+| Dang o dau | Mac dinh anh feed 4:5. Ghi ro |
+
+Doc `product-marketing-context` / Brand Hub / `35-brand-voice` neu co.
+
+### Buoc 1 — Tim moc noi, roi moi chon cong thuc
+
+Di 5 moc theo thu tu (chi tiet: `references/tim-moc-noi.md`):
+
+1. Ten rieng / thanh ngu quen → chen 1-2 chu
+2. Dong tu cua dip → nghia thu hai trong nganh minh
+3. Thuoc tinh noi bat (nhanh/cham, day/mong, nong/lanh) → so voi thuoc tinh san pham, **nguoc thuong manh hon cung chieu**
+4. So (ngay, gia, so hieu, ty so)
+5. Canh cu the (mua, ket xe, tet, tang ca) — san pham phai **co mat va co viec** trong canh
+
+Khong moc nao danh → dung, noi that. Dung "chuc ca nha vui ve" gia lam hai lop.
+
+### Buoc 2 — 8 cong thuc (chon 3-5, khong dung het)
+
+Bang ngan. Mach viet + vi du VN nam o `references/cong-thuc-hai-lop.md`.
+
+| # | Cong thuc | Dung khi |
+|---|-----------|----------|
+| 1 | Chen chu / doi am vao thanh ngu quen | Dip co ten, brand co am tiet de chen |
+| 2 | So hai nghia | Dip hoac gia co so trung voi san pham |
+| 3 | Chiem nghia tu nganh | SaaS, giao duc, dich vu chuyen mon |
+| 4 | Vat the len tieng | Khong co san pham vat ly, hoac san pham khong gong duoc an du |
+| 5 | Tach chu / Han Viet | Ten ngan, 1 chu goc, le tiet khi |
+| 6 | Cap doi / lich Nen Ky | Series le, calendar content |
+| 7 | Tho 3 canh + 1 drop | User xin ban dai; **khong len poster** |
+| 8 | Giu minh | Dip khong nen dua; toi da ~5 lan / nam |
+
+Mot cau chi dung **mot** lan doi am. Hai lan = van vat.
+
+### Buoc 3 — Giao 3-5 the, bat user chon
+
+Moi the bat buoc khac cong thuc + khac chu the hinh.
+
+```
+A | <ten cong thuc>
+Cau ngan: ...
+Lop mat: ...
+Lop trong: ...
+Chuoi nhay: [mat] → [trong]   (dung 1 mui ten)
+Chu the hinh: san pham / dao cu / chu lon
+Giong: 1 cau
+```
+
+Neu user xin ban dai: viet **full 1 the ban tin dung nhat**, the con lai chi ghi dang (tho / vat the noi / list).
+
+Sau the: **mot** cau hoi — chon the nao, ti le nao (4:5 feed / 1:1 / 9:16 / 16:9). Neu user da noi kenh, dung hoi ti le.
+
+### Buoc 4 — Chot cau + brief visual (khong render)
+
+Skill nay **khong xuat file anh**. Ly do: repo da co `42` va `30`; pipeline render cua nguon OSS khong phu hop stack VN va de keo theo font/IP.
+
+Brief ngan cho designer / `42`:
+
+- Chu the: san pham (15-35% khung) / dao cu 1 mon / chu lon
+- Bo cuc: trai chu phai hinh | tren chu duoi hinh | chu giua | chu nam tren vat | gia giao dien
+- Mau: uu tien mau brand. Khong co brand thi ghi 1 bo (toi / giay am / 1 mau nhan)
+- Chu tren hinh = cau ngan da chot. Khong nhan dien them.
+- Font: chi font duoc phep thuong mai. "May dang co" khong bang "duoc dung".
+- 1 poster = 1 bo mau. Doi khung hinh la ve lai, khong scale.
+
+Chi tiet khung: `references/khung-visual-hai-lop.md`.
+
+## Bien gioi cung — vi pham thi viet lai, khong sua le
+
+1. Khong dua len tham hoa, tai nan, chet choc, dich benh, lu, chay, sap cau — tru campaign cong ich ro rang.
+2. Khong vat hoa phu nu, khong dung nguoi nhu bo phan co the.
+3. Khong an y tinh duc len nguoi that, dac biet khong lien quan tre em. San pham 18+ khong nham tre em.
+4. Khong an dip buon / hotspot thuong tam cua nguoi khac.
+5. Khi chuyen sang nganh khong phai 18+: lop trong phai la **gia tri san pham**, khong phai tro sex.
+6. Khong copy cau hay poster cua hang nuoc ngoai. Hoc co che, viet cau moi cho brand VN.
+7. Nganh nha nuoc quan (thuoc, my pham claim, tai chinh, thuc pham chuc nang): khong de hai nghia tao hieu nham cong dung / chua benh / giam can.
+8. Khong so sanh truc tiep bang ten doi thu (Luat Canh tranh). Khac biet noi o viec minh lam, khong o ten hang kia.
+9. Nguoi that / KOL / mat celeb: can consent. Khong co phep thi anonymize hoac dung dao cu.
+10. Quang cao nhay cam (18+, dip buon, nganh quan): **nguoi duyet** truoc khi dang. 62 khong thay nguoi.
+11. Output giao khach / dang public: khong ghi Durex, Reckitt, khong claim affiliation. Trigger "nhu Durex" chi de nhan intent, khong de in ra ngoai.
+
+## Cau truc ket qua
+
+```
+# Copy hai lop — [san pham] — [YYYYMMDD]
+
+Gia dinh dang dung:
+- Doi tuong:
+- Kenh / ti le:
+- Co / khong co dip:
+
+## The phuong an
+[3-5 the dung format Buoc 3]
+
+## The khuyen dung
+- Chon: [chu]
+- Ly do 1 cau:
+- Chuoi nhay (1 mui ten):
+- Vi sao khong chon the kia (1 dong / the):
+
+## Cau chot
+- Tren hinh (<=12 chu):
+- Pho (neu can, nho hon):
+- Caption dai (neu user xin; khong len hinh):
+
+## Brief visual giao 42
+- Chu the + bo cuc + mau + font an toan + copy overlay dung cau chot
+
+## Tu cham
+- [ ] Mot nhip
+- [ ] Khong diem to
+- [ ] Roi vao "ban"
+- [ ] Khac that giua cac the
+- [ ] Khong vuot bien gioi
+- [ ] Khop brand voice
+
+## Handoff
+- Can anh: `42-brief-hinh-anh` (hoac `30` neu gen AI, NO TEXT in image)
+- Can len ads: `05-copy-quang-cao`
+- Can caption dai: `37-caption-social`
+- Can duyet: `62-marketing-review`
+```
+
+## Lien ket skill
+
+- `35-brand-voice`: doc truoc — person, banned words, do dua duoc phep.
+- `36-content-brief` / `09-insight-khach-hang`: insight va ngon ngu khach = nguyen lieu moc noi.
+- `58-positioning`: chot Promise truoc khi 74 viet cau; 74 khong tu dinh vi.
+- `42-brief-hinh-anh`: nhan brief visual sau khi cau da chot.
+- `05-copy-quang-cao`: viet lai khi cau nay phai chay tien.
+- `37-caption-social`: dan cau ngan thanh caption organic.
+- `16-marketing-psychology`: neu can trigger (khan hiem, proof) — dung o caption/ads, khong nhet vao cau poster.
+- `66-crisis-playbook`: dip nhay cam chi duoc Giu minh.
+- `62-marketing-review`: gate truoc khi dang / in.
+
+Chi tiet: `references/tim-moc-noi.md`, `references/cong-thuc-hai-lop.md`, `references/doi-am-tieng-viet.md`, `references/ngon-tu.md`, `references/khung-visual-hai-lop.md`, `references/bien-gioi-va-nguon.md`. Vi du spa: `references/vi-du-spa.md`.
+
+## Checklist chat luong
+
+- [ ] "Ban gi" ro, hoac da hoi 1 cau roi dung
+- [ ] 3-5 the khac cong thuc va khac chu the hinh
+- [ ] Moi the ghi lop mat, lop trong, dung 1 mui ten
+- [ ] Cau tren hinh <= 12 chu (tru cap doi)
+- [ ] Khong cau nao tu giai thich minh
+- [ ] Chu ngu la "ban" / vat the, khong "moi nguoi" / "chung ta hay cung"
+- [ ] Khong dung tinh tu quang cao (toi uu, vuot troi, dang cap, tan tam)
+- [ ] Khong vuot 11 bien gioi (ke ca ten doi thu, consent, claim y te)
+- [ ] The lech brand voice da bi loai, du hay
+- [ ] Co handoff ro sang 42 / 05 / 37 — khong gia lam ads copy
+- [ ] Output public khong nhac Durex / Reckitt nhu affiliation

--- a/skills/vi/74-copy-hai-lop/references/bien-gioi-va-nguon.md
+++ b/skills/vi/74-copy-hai-lop/references/bien-gioi-va-nguon.md
@@ -1,0 +1,72 @@
+# Bien gioi, license, va cai gi KHONG duoc nhap
+
+## Nguon method
+
+Skill `74-copy-hai-lop` **thich nghi** (khong copy nguyen) co che tu:
+
+- Repo: [crawfordxx/xiaoma-durex-copywriter](https://github.com/crawfordxx/xiaoma-durex-copywriter)
+- Commit tham chieu: `d892bfb7bcae28e6758fa318093f6774d99b7eba` (2026-08)
+- License **code + van ban huong dan**: MIT, Copyright (c) 2026 crawfordxx
+- Dieu kien MIT: giu copyright notice khi phan phoi phan mem / van ban goc. Day la ban **viet lai + dia phuong hoa VN**, khong phai ban dich mot-mot.
+
+> Adapted from [xiaoma-durex-copywriter](https://github.com/crawfordxx/xiaoma-durex-copywriter) by crawfordxx, MIT License.
+
+MIT **khong** bao poster trong `examples/durex-reference/`. File LICENSE cua nguon ghi ro: anh poster thuoc Durex / Reckitt Benckiser, chi de hoc, khong de tai su dung thuong mai.
+
+Ten skill **khong** chua "durex". Trigger `'an y nhu Durex'` chi de nhan intent nguoi dung. Output giao khach / dang public **khong** nhac Durex / Reckitt nhu affiliation.
+
+## Cai duoc nhap (y tuong, viet lai)
+
+| Y tuong | Xu ly trong 74 |
+|---------|----------------|
+| Hai lop nghia + de trong | Viet lai, vi du VN moi |
+| Mot nhip nhay, diem to la chet | Giu nguyen luat, khong giu cau goc |
+| 5 moc noi truoc cong thuc | Dia phuong hoa (thanh ngu VN, dip VN) |
+| 8 cong thuc rhetoric | Viet lai ten + vi du nganh VN |
+| Giong ngan, dong tu, khong tu giai thich | Bang AI-vs-nguoi cho tieng Viet |
+| 3-5 the khac nhau, it hoi | Giu; van tuan thu "toi da 4 cau" cua repo |
+| Cay chu the hinh + khung ty le | Rut thanh brief, giao `42` / `30` |
+| Bien gioi: tham hoa, vat hoa, tre em, dip buon | Giu + them luat QC VN / nganh claim |
+
+## Cai CAM nhap
+
+| Tai san nguon | Ly do |
+|---------------|--------|
+| Poster Durex / Reckitt, ca ban low-res | Ban quyen hang. Hoc duoc, khong ship |
+| Corpus cau goc 2011-2017 | Van la copy thuong mai cua hang. Khong dan lai de "hoc giong" |
+| Script render (Playwright / Canvas) + font CJK | Ngoai pham vi repo; de keo font khong phep |
+| Bang mau #E2001A nhu "bo mau mac dinh" | Do la nhan dien hang nguoi ta, khong phai cua user |
+| Tro sex lam lop trong mac dinh | Chi hop 1 nganh; user VN da co 05/37 manh hon o conversion |
+
+## Vi sao khong thay 05 / 37
+
+Doi chieu nhanh (bang day du nam o quyet dinh Operator, 2026-08-16):
+
+| Truc | 05 + 37 (giu) | Nguon OSS | 74 (them) |
+|------|----------------|-----------|-----------|
+| Muc tieu | Chuyen doi, policy, pheu | Truyen / "toi hieu roi" | Slogan + poster ngan |
+| Do dai | 125 / 300-500 ky tu | <=12 chu Trung | <=12 chu Viet |
+| Output | 6 bien the ads / 2 caption | Cau + 5 anh | Cau + brief, khong render |
+| Thi truong | VN ads 2025-26 | Weibo / Xiaohongshu | VN feed / poster / le |
+| Rui ro | Claim, Ads Policy | Font CJK, 18+, IP poster | Bien gioi VN + routing ve 05 |
+
+05 manh hon o viec **ban duoc hang bang ads**. Khong duoc de 74 de len lane do.
+
+## Luat va rui ro VN (khong phai tu van phap ly)
+
+Day la ranh gioi van hanh, khong phai tu van luat su.
+
+| # | Ranh gioi | Ly do thuc te |
+|---|-----------|----------------|
+| 6 | Khong so sanh truc tiep bang ten doi thu | Luat Canh tranh 2018 — quang cao so sanh phai khach quan, khong naming & shaming |
+| 7 | Khong claim chua benh / giam can / hieu qua dieu tri | Luat Quang cao — nganh thuoc / TPCN / my pham de hai nghia "vuot claim" |
+| 8 | Nguoi that / KOL can consent | Quyen hinh anh. Khong co phep thi blur / dao cu |
+| 9 | 18+ khong nham tre em | Luat Quang cao. Cam an y, cam hinh tre |
+| 10 | Khong khai thac hotspot thuong tam (lu, chay, sap cau) | Phan cam xa hoi + brand risk; chi Giu minh hoac dung |
+| 11 | Quang cao nhay cam: nguoi duyet truoc dang | `62` khong thay human approval |
+
+- My pham, thuc pham chuc nang, thuoc, tai chinh: neu hop dong / Bo Y te / NHNN quan → **khong dung 74**, ve 05 + 62 + nguoi duyet.
+- Logo hang khac, font "co san tren may": can phep rieng. Font mac dinh an toan: **Be Vietnam Pro** (SIL OFL). 74 khong vendor font CJK cua repo nguon.
+- Corpus slogan goc (neu doc de hoc): quotation hoc tap. **Cam** paste lam output thuong mai.
+
+Khi nghi ngo: dung, ghi ly do, chuyen `62` hoac `66`.

--- a/skills/vi/74-copy-hai-lop/references/cong-thuc-hai-lop.md
+++ b/skills/vi/74-copy-hai-lop/references/cong-thuc-hai-lop.md
@@ -1,0 +1,171 @@
+# 8 cong thuc — viet lai cho tieng Viet
+
+Moi cong thuc: co che → cach lam → vi du nganh VN **tu viet**. Khong dan cau goc hang nuoc ngoai.
+
+Vi du la huong, khong phai kho cau de copy khi lech nganh.
+
+---
+
+## 1. Chen chu / doi am vao thanh ngu
+
+**Co che:** Lay cum ca nuoc biet, doi 1-2 chu / 1 am. Nguoi doc nghe dong thoi cu va moi.
+
+**Lam:** liet ke 10 thanh ngu gan dip → thu chen am brand hoac dong tu nganh → cum van thanh cau.
+
+**Vi du huong**
+
+- Khoa AI: "khong tien thi lui" → "khong hoi thi lui" (prompt = cau hoi)
+- Quan com: "an no roi tinh" giu nguyen neu brand la ve no, khong them chu
+- Spa: "ve sinh la ve dep" — chi dung neu dich vu that la ve sinh da, khong keo mien cuong
+
+**Canh bao:** de tuong tuc. Mot cau mot lan. Cum khong ai thuoc = do.
+
+---
+
+## 2. So hai nghia
+
+**Co che:** Mot so dung o dip va o san pham.
+
+**Lam:** so dip + so that cua hang + **mot dong tu** han hai ben.
+
+**Vi du huong**
+
+- Khoa 3 gio: "3 gio hoc, bot 3 nam do do"
+- Lieu trinh 21 ngay: "21 ngay. Khong phai 21 lo kem."
+- 1 phan an 1 nguoi: "Mot phan. Dung mot ghe."
+
+Khong them "len toi", "tan", "gan". So tu no noi.
+
+---
+
+## 3. Chiem nghia
+
+**Co che:** Lay tu nganh (nghe cho dung), dung **nghia mat chu** trong canh khach.
+
+**Lam:** liet 15 tu nganh → hoi "mat chu nghia gi?" → giu tu nao ve duoc hinh.
+
+**Vi du huong (SaaS / AI / giao duc)**
+
+- Ao giac: "Ao khong o may. Ao o cho ban tuong minh biet hoi."
+- Rollback: "Cho phep ban hoi han."
+- Cua so ngu canh: "Cau hoi dai qua, no het kien nhan."
+- Giu cho (F&B): "Giu cho. Khong giu gia."
+
+Manh voi B2B nhe va khoa hoc. Yeu voi ba noi khong xai tu do.
+
+---
+
+## 4. Vat the len tieng
+
+**Co che:** Vat phu trong canh noi mot cau phan nan / tu hao. Nguoi doc tu suy ra nhan vat chinh.
+
+**Lam:** chon 1 vat khach thay hang ngay → ngoi thu nhat → 1 cau. Khong giai thich vat dang noi ve ai.
+
+**Vi du huong**
+
+- Khoa AI cho team van phong — may in: "Ba thang nay khong ai bao 'in lai ban nay'."
+- Dem em be — den ban: "Toi cung muon tang ca, nhung ho tat toi som."
+- Nem — dong ho bao thuc: "Lau roi khong bi quang."
+- Tai nghe chong on — tau dien: "No nhu khong quen toi nua."
+
+Day la cong thuc tot nhat khi **khong co hop san pham de chup**.
+
+---
+
+## 5. Tach chu / Han Viet
+
+**Co che:** Tieng Viet it "thao chu Han" hon tieng Trung. Chi dung khi co 1 chu goc ro hoac ten ngan tach am van nghe duoc.
+
+**Lam:** viet chu chu de → tach am / goc Han neu khach that su biet goc do → dat lai thanh cau. Neu phai chu thich goc Han → **bo**, khach khong nhay.
+
+**Vi du huong**
+
+- "An" trong an toan / an com — chi dung nganh an uong hoac an toan that
+- Ten brand 2 am: am 1 = viec khach lam, am 2 = ket qua
+
+De lam sang. Khong ep. Neu khong chac, dung cong thuc 1 hoac 6.
+
+---
+
+## 6. Cap doi / lich Nen Ky
+
+**Co che:** Hai ve song song, doi 1-2 chu. Hoac o Nen / Ky nhu to lich.
+
+**Lam:** `viec dam dang lam` + "khong bang" / "nen" + `viec muon khach lam`. Hai ve cung nhip.
+
+**Vi du huong**
+
+- "Doc tram bai. Khong bang chay het mot viec."
+- Nen | lam thu    Ky | cat di roi quen
+- "Ket tren duong khong bang ngoi het ly."
+
+Hop series le, calendar content. Giu form 1 nam = tai san re.
+
+---
+
+## 7. Tho 3 canh + 1 drop
+
+**Co che:** Ba canh trang, it tinh tu. Cau cuoi moi roi vao nguoi. **Chi dung khi user xin ban dai. Khong len poster.**
+
+**Khung**
+
+```
+[vat] [dong tu]
+[canh xa]
+
+[vat] [dong tu]
+[canh giua]
+
+[vat] [dong tu]
+[canh gan]
+
+[cau roi vao ban]
+```
+
+**Vi du huong (khoa hoi AI)**
+
+```
+Gio di
+het tang van phong
+
+Den con
+o file Chua dat ten
+
+Con tro
+dung dong mot
+
+Ban tuong thieu y.
+Thieu mot cau hoi.
+```
+
+Tu cham: xoa cau cuoi, ba canh con la canh that khong? Khong → bo ca bai. De suyen.
+
+---
+
+## 8. Giu minh
+
+**Co che:** Dip moi nguoi cho dua — khong dua. Mot cau that, het muc ngan.
+
+**Khi nao:** le chet, tai nan, lu, chay, sa thai hang loat, dip y te. Hoac 1-2 lan / nam de brand "duoc phep dua" van biet dung.
+
+**Vi du huong** (viet lai theo brand that, dung lay nguyen neu khong dung)
+
+- Dip ve que: "Ve som."
+- Dip tin don AI: "No tra loi giong cach ban hoi."
+- Dip cat giam nhan su nganh: "May thay may. Khong thay nguoi biet hoi."
+
+Khong dung de gia bo dao duc moi tuan. Qua 5 lan / nam la trang stt truyen cam hung.
+
+---
+
+## Ghep the — bat buoc khac nhau
+
+Khi giao 3 the, vi du pho:
+
+| The | Cong thuc | Chu the hinh |
+|-----|-----------|--------------|
+| A | Chen chu | Chu lon |
+| B | Vat the noi | Dao cu 1 mon |
+| C | Giu minh hoac cap doi | San pham hoac chu + nhieu trang |
+
+Ba the cung "trai chu, phai hop" = fail, du doi mau.

--- a/skills/vi/74-copy-hai-lop/references/doi-am-tieng-viet.md
+++ b/skills/vi/74-copy-hai-lop/references/doi-am-tieng-viet.md
@@ -1,0 +1,80 @@
+# Doi am tieng Viet — khong dich pun Trung
+
+Repo nguon dung **谐音 / 拆字** (am Han). Dich may la mat nhip. File nay la playbook **tu viet** cho tieng Viet.
+
+Day la catalog co che, khong phai kho cau de copy.
+
+## 1. Dong am khac nghia (manh nhat)
+
+Mot tu, hai viec. Nguoi doc da biet ca hai nghia.
+
+| Tu / cum | Nghia mat | Nghia nganh co the |
+|----------|-----------|--------------------|
+| ve | tro ve nha | da / toc / ket qua "ve dung cho" |
+| giu | giu cho, giu gia | giu khach, giu form |
+| chot | chot don | chot y, het do do |
+| mo | mo cua | mo lop, mo lieu trinh |
+| o | o lai | o dung cho (da, nha, file) |
+| hoi | hoi tham | prompt / cau hoi AI |
+| an | an com | an toan |
+| nang | nang len | nang da, nang cap goi |
+| ben | ben bi | khong vo, khong sap |
+
+Chi dung khi **ca hai nghia that**. Gan "ben" cho hang dung 1 lan = do.
+
+## 2. Noi lai / dao van
+
+Dao 2 am van cua cum quen, van nghe duoc ca cu va moi.
+
+- Cum goc phai la cum ba noi thuoc trong 1 giay.
+- Chi dao **mot** cap. Dao 2 cap = do vui.
+- Neu phai chu thich "day la noi lai cua..." → bo.
+
+Huong (tu viet cau moi, dung lay lam slogan san):
+
+- "yen binh" ↔ "binh yen" — chi khi brand that su noi ve yen
+- "cua hang" ↔ viec "hang cua" chi dung nganh ban le / ship
+
+De gia tao hon dong am. Uu tien muc 1.
+
+## 3. Tuc ngu / thanh ngu lat 1-2 chu
+
+Lay cum ca nuoc thuoc, doi 1-2 chu sang viec san pham lam.
+
+Luat:
+
+1. Cum goc ai cung thuoc.
+2. Dong 1-2 chu, khong 3.
+3. Cum moi van la cau, khong thanh slogan-y.
+
+Huong: xem cong thuc 1 trong `cong-thuc-hai-lop.md`. Khong lap kho tuc ngu o day — liet ke luc viet, theo dip.
+
+## 4. Tach chu / goc Han-Viet (hiem)
+
+Chi dung khi khach **that su biet** goc chu (an, nhan, dai, tam) hoac ten brand 2 am tach ra van nghe.
+
+Neu phai chu thich goc Han → **bo**. Day khong phai thi tho Han-Viet.
+
+## 5. So doc / so that
+
+So dip trung so san pham (21 ngay, 90 phut, 3 gio, 1 ghe).
+
+Khong dung so "ma" Trung (69, 419, 001) lam lop trong mac dinh. O VN so do hoac vo nghia hoac keo ve 18+ khi nganh khong phai 18+.
+
+## 6. Cai nao **khong** mang tu Trung sang
+
+| Co che Trung | Xu ly VN |
+|--------------|----------|
+| 谐音 杜/独, 湿/十 | Bo. Khong co tuong duong am |
+| 拆字 「日」 | Bo, tru 1 chu Han-Viet khach da biet |
+| 69 / 419 / 001 nhu ma | Khong mac dinh. Chi nganh 18+ va user xin |
+| innuendo Anh ("that's what she said") | Khong dung o lane VN. Mirror Global sau nay tu viet |
+
+Cong thuc 4-8 (vat the noi, cap doi, tho, giu minh) **khong phu thuoc am**. Uu tien khi doi am lech.
+
+## 7. Tu cham truoc khi giu 1 cau doi am
+
+- [ ] Ba noi hieu ca hai nghia ma khong can chu thich
+- [ ] Mot lan doi am / mot cau
+- [ ] Lop trong la viec brand lam that, khong phai tro chu
+- [ ] Khong can dong chu Han de "ra ve hay"

--- a/skills/vi/74-copy-hai-lop/references/khung-visual-hai-lop.md
+++ b/skills/vi/74-copy-hai-lop/references/khung-visual-hai-lop.md
@@ -1,0 +1,85 @@
+# Brief visual hai lop — giao 42 / 30, khong render o day
+
+74 chot **cau** va **y hinh**. `42-brief-hinh-anh` moi la brief day du. `30-thiet-ke-master` moi gen anh (cam chu trong anh).
+
+## Cay chu the
+
+```
+Co hop / mon that de chup?
+├─ Co, va hinh dang / cong dung gong duoc an du
+│   → CHU THE SAN PHAM, 15-35% khung, nen sach, 1 nguon sang
+└─ Khong gong, hoac la dich vu / khoa / SaaS
+    ├─ DAO CU 1 MON khach thay hang ngay (coc, lich, cong tac, thung, tai nghe)
+    └─ CHU LON = hinh (khong can mon)
+Nguoi: tranh nguoi du. Neu bat buoc: 1 bo phan (tay, lung, bong). Khong anh giang vien toan than tren cover khoa.
+```
+
+San pham khong gong an du thi **thu nho goc 5-10%**, de dao cu noi.
+
+## Sau khung, roi moi ty le
+
+Doi ty le la ve lai, khong phong to.
+
+| Khung | Khi nao |
+|-------|---------|
+| Trai chu, phai hinh | Co mon / dao cu |
+| Tren chu, duoi hinh | Feed dung, mon nam duoi |
+| Chu giua, nhieu trang | Khong mon, muon sach |
+| Chu nam tren vat | Dong ho, man hinh, tem gia, to lich — vat "noi" bang cho chu |
+| Gia giao dien | Chat, lich, o chat — chi khi khach nhan ra giao dien do |
+
+Ra 3 the: **doi khung + doi chu the**, roi moi doi mau. Cung khung doi mau = mot y doi ao.
+
+## Ty le VN (goi y, 42 chot spec)
+
+| Ty le | Cho |
+|-------|-----|
+| 4:5 | Feed FB/IG — mac dinh |
+| 1:1 | Avatar, cover o vuong, pin |
+| 9:16 | Story, TikTok cover, Zalo story |
+| 16:9 | Cover web, YouTube, slide |
+| 3:4 | Poster in, bai dai |
+
+Cau tren hinh: 4:5 toi da ~3 dong; 1:1 toi da 2; 16:9 tot nhat 1 dong.
+
+## Mau
+
+1. Co brand guideline (`46`) → dung mau brand. Khong lay do Durex.
+2. Khong co → 1 bo thoi: den + 1 mau nhan, hoac giay am + muc, hoac trang + 1 mau.
+3. Mot anh mot bo. Khong pha 2 he mau.
+
+## Font
+
+Chi font **duoc phep thuong mai**. "Co tren may" khong du.
+
+An toan thuong gap: Be Vietnam Pro, Inter, Source Sans, Noto Sans (SIL OFL). Font Viet hoa khong ro giay phep → khong ghi vao brief.
+
+Muon giong mot hang khac (borrowed interest): **can phep**. Khong bat designer gia font / gia UI hang do.
+
+Ghi ten font vao brief.
+
+## Luat xep (de 42 / designer giu)
+
+- Cau nam 1/3 tren hoac trai tren. 1/3 duoi de trong hoac de mon.
+- Mot tu can nhan: to hon ~1.7 lan, to mau nhan. Con lai cung co, cung mau.
+- Logo nho, day, nam tren nen trong. Mon khong de len logo.
+- Trong >= nua khung. Chen = re.
+- Tren hinh chi cau da chot. Caption dai o bai viet, khong nhan them len poster.
+
+## Neu dung 30 de gen nen
+
+Prompt phai co: `NO text, NO letters, NO numbers, NO logos`. Chu do CSS / Figma / Canva them sau. Model van hay viet sai tieng Viet.
+
+## Block copy sang 42
+
+```
+Muc tieu hinh: dung cuon / 1 nhip "hieu roi" (khong phai CTA mua)
+Cau overlay (chinh): ...
+Cau overlay (pho, neu co): ...
+Chu the: san pham | dao cu [ten] | chu lon
+Khung: ...
+Ty le: ...
+Mau: lay tu 46 / [hex]
+Font: [ten, giay phep]
+Cam: chu them, nguoi du, 2 he mau, gia UI hang khac
+```

--- a/skills/vi/74-copy-hai-lop/references/ngon-tu.md
+++ b/skills/vi/74-copy-hai-lop/references/ngon-tu.md
@@ -1,0 +1,85 @@
+# Ngon tu — cho cau giong nguoi viet
+
+Cong thuc lam cau **dung**. File nay lam cau **khong giong may**.
+
+Doc truoc khi viet, cham lai sau khi chot.
+
+## 1. Ngan la ket qua, khong phai muc tieu
+
+Cau tren poster: 4-8 chu la pho. Qua 12 chu ma khong phai cap doi → cat.
+
+Thu tu: **mot nhip da toi → roi moi cat**. Cat mat an du thi cau thanh do vui. Do vui khong ai nhay.
+
+## 2. Dau cau la giong, khong phai ngu phap
+
+| Dau | Viec no lam | Khi dung |
+|-----|-------------|----------|
+| . | Chat, het chuyen | Ten le. Ten viec. |
+| ~ | Nhe, ngo | Loi goi ngan, dung qua 1 lan / the |
+| ! | Gat mot cai | It. Hai dau cham than = la |
+| ? | Hoi ma da biet dap | "An chua?" dung hon doan chuc |
+| ... | De nguoi doc di tiep | Chi o pho, khong o cau chinh neu da du |
+
+Phay de ngat nhip ("an toan, truoc"), khong de noi menh de phu.
+
+## 3. Dong tu. Gan nhu khong tinh tu
+
+Uu tien dong tu khach dung: ve, o, giu, chot, uong, hoi, bo, de, mang, ngoi.
+
+Vua viet da muon xoa: toi uu, vuot troi, dang cap, tan tam, chuyen nghiep, toan dien, dong hanh, kien tao, bat dau hanh trinh, nang tam.
+
+Thay tinh tu bang dong tu duoc thi thay.
+
+## 4. Chen vao cum quen, dung dat tu moi
+
+May thich de "he sinh thai trai nghiem tinh thuc". Nguoi khong noi vay.
+
+Hai luat:
+
+1. Cum goc phai la cum ba noi cung biet trong 1 giay.
+2. Chi dong 1-2 chu.
+
+## 5. Ngoi tu
+
+- **Ban** — mac dinh
+- **Toi / minh** — khi brand hoac vat the noi
+- Vat the — chi o cong thuc 4
+
+Gan nhu khong dung: quy khach, moi nguoi, cac ban, chung ta hay cung, nguoi dung.
+
+"Moi nguoi" = giong thong bao phuong. Het nguoi.
+
+## 6. Khong tu giai thich
+
+Xoa ngay neu xuat hien:
+
+> dieu nay co nghia · that ra · noi cach khac · ly do la · suc manh cua · do chinh la · mot nhip nha ay
+
+Viet xong cau thi dung. De trong la viec cua nguoi doc, khong phai viec cua doan sau.
+
+## 7. So dung lam chu, khong lam tinh tu
+
+199. 3 gio. 21 ngay. 1 ghe.
+
+Khong: "len toi 199", "tan 3 gio vang ngoc", "gan 21 ngay ky dieu".
+
+## 8. Bang may / nguoi (cham het moi cau)
+
+| May hay viet | Huong nguoi |
+|--------------|-------------|
+| Cung nhau bat dau hanh trinh moi | Len xe. / Vao. |
+| An toan luon la uu tien hang dau | An toan, truoc. |
+| Nhan dip le, chuc gia dinh hanh phuc | An chua? / Ve som. |
+| San pham mong nhe, sat da | Mong. Het. |
+| Dong hanh cung ban tren moi chang duong | (xoa. Khong thay. Bo cau.) |
+
+Benh chung: noi het, ke het loi, ke het cam xuc. Cach chua: noi mot nua.
+
+## 9. Tu cham 6 dong
+
+- [ ] Cau chinh <= 12 chu, hoac la cap doi
+- [ ] Co 1 dau cau dang giu giong (khong phai toan cham het nhu van ban hanh chinh)
+- [ ] Tinh tu doi duoc sang dong tu thi da doi
+- [ ] Khong tu giai thich
+- [ ] Ngoi tu la ban / vat, khong "moi nguoi"
+- [ ] Doc to. Giong hai nguoi noi voi nhau. Khong giong thi viet lai

--- a/skills/vi/74-copy-hai-lop/references/tim-moc-noi.md
+++ b/skills/vi/74-copy-hai-lop/references/tim-moc-noi.md
@@ -1,0 +1,84 @@
+# Tim moc noi — lam truoc khi chon cong thuc
+
+Cong thuc chi la cach viet. Buoc nay quyet dinh **co nen viet khong**.
+
+Quy tac nguon (viet lai): dip khong dan vao brand thi **bo**. Dang mot cau mung le chung la viec cua lich, khong phai viec cua 74.
+
+## 1. Cham dip voi 5 moc
+
+Thu tung moc. Danh duoc 1 moc thi viet. Khong moc nao — dung.
+
+### Moc 1 — Ten / thanh ngu quen
+
+Chen 1-2 chu vao cum **ca nuoc deu thuoc**. Cum tu che = chet.
+
+| Dip / chat lieu | Cum quen | Huong viet (tu lam cau moi, dung copy hang khac) |
+|-----------------|----------|--------------------------------------------------|
+| Ten brand 1-2 am | "an cu lac nghiep", "co chi thi nen" | Chen am brand, van doc duoc nghia cu |
+| Ten le | "be ngoai be trong", "di mot ngay dang" | Doi 1 chu sang viec san pham lam |
+| Ten mon / ten goi | "het hon", "ve som" | Giu nhip noi cua khach |
+
+Chi dong 1-2 chu. Dong 3 chu la ra tu moi, mat nhip nhay.
+
+### Moc 2 — Dong tu cua dip
+
+Dong tu dip co nghia thu hai trong nganh minh khong?
+
+| Dip | Dong tu | Nganh co the dung |
+|-----|---------|-------------------|
+| Khai truong / khai giang | mo, vao, len | khoa hoc, phong tap, spa lieu trinh |
+| Mua, ngap, ket xe | ve, o lai, len | F&B giao hang, sua xe, noi that |
+| Black Friday / sale | ha, giu, chot | chi khi giam that — khong bia so |
+| World Cup / chung ket | giu, do, da | nganh co "ben" / "khong vo" that |
+
+### Moc 3 — Thuoc tinh (nguoc thuong thang)
+
+Lay thuoc tinh noi cua dip, dat canh thuoc tinh that cua san pham.
+
+| Dip noi | San pham | Huong |
+|---------|----------|-------|
+| Nhanh, so 1, ky luc | Dich vu ben, lieu trinh dai | Nhanh khong bang o lai duoc |
+| To, hoanh trang | San pham mong / nhe / it buoc | To khong phai luc nao cung tot |
+| Nong, sot hang | San pham lam mat, lam diu | Sot ngoai / lanh trong |
+
+Phai **that**. Khong gan "ben" cho hang dung mot lan.
+
+### Moc 4 — So
+
+Ngay le, gia, so hieu goi, so cho, so buoc. So tu no la luoi hai nghia. **Khong** them "len toi", "tan", "toi".
+
+Vi du huong: goi 90 phut ↔ 90 ngay thu; 3 buoc ↔ 3 nam lam sai; gia 199K ↔ 199 lan do do.
+
+### Moc 5 — Canh cu the
+
+Dip mang mot canh: mua, tang ca, ve que, ship tre, het phong.
+
+San pham phai **xuat hien va lam duoc viec** trong canh. Chi viet chu chuc = that bai.
+
+Spa: lich day ↔ "ve som".
+Quan ca phe: ly nguoi ↔ "de nguoi van uong".
+Sua ong nuoc: nha ngap ↔ viec that cua tho, khong dua len thiet hai hang xom.
+
+## 2. Cham roi vao "ban"
+
+| Yeu (noi ve hang) | Manh (noi ve nguoi doc) |
+|-------------------|-------------------------|
+| 0 duong, khong lo | Uong xong khong phai tu thuong |
+| Vai tot, ben 2 nam | Mua luc do, gio van mac |
+| An toan, tieu chuan | Ve som. O nha. |
+
+Doc to: chu ngu la san pham hay la nguoi doc? San pham → viet lai.
+
+## 3. Cua so dip
+
+Dip mang (ket qua bong, mua cuc, trend 1 ngay): khong ra cau trong vai gio thi **bo**. Cau gắng di sau 2 gio chi lam loang brand.
+
+Dip lich (Tet, 8/3, Trung thu, 20/10, Black Friday): chuan bi truoc, van phai co moc that.
+
+## 4. Tu cham
+
+- [ ] Noi duoc moc nao da danh?
+- [ ] Khong noi duoc → bo dip
+- [ ] Roi vao nguoi doc, khong vao thong so
+- [ ] Mot mui ten tu mat sang trong
+- [ ] San pham (hoac dao cu dung viec) co cho tren hinh

--- a/skills/vi/74-copy-hai-lop/references/vi-du-spa.md
+++ b/skills/vi/74-copy-hai-lop/references/vi-du-spa.md
@@ -1,0 +1,46 @@
+# Vi du — spa lieu trinh 21 ngay, le 8/3
+
+Gia dinh: dang anh feed 4:5, khach nu 28-40, da nam, khong chay ads.
+
+## The phuong an
+
+A | Chen chu
+Cau ngan: Ve som.
+Lop mat: le, ve nha som
+Lop trong: lieu trinh ngan, khong de da "o lai" nua
+Chuoi nhay: ve som → da cung duoc ve
+Chu the hinh: chu lon
+Giong: chat, het chuyen
+
+B | Vat the len tieng
+Cau ngan: Lich noi: het o.
+Lop mat: to lich het cho
+Lop trong: lieu trinh kin lich that
+Chuoi nhay: lich het → ban nen giu cho
+Chu the hinh: dao cu (to lich)
+Giong: vat phan nan
+
+C | Cap doi
+Cau ngan: 21 lo. Khong bang 21 ngay.
+Lop mat: so kem vs so ngay
+Lop trong: lieu trinh, khong mua them hu
+Chuoi nhay: 21 = 21
+Chu the hinh: san pham (1 hu nho goc)
+Giong: doi, it chu
+
+## The khuyen dung
+
+Chon C. So that cua lieu trinh, mot nhip, khong dua le. A dung neu brand da noi ngan 1 nam; B yeu hon neu lich khong kin that.
+
+## Cau chot
+
+- Tren hinh: 21 lo. Khong bang 21 ngay.
+- Caption dai: dua 37 neu can. Khong len hinh.
+
+## Brief visual
+
+Chu the san pham 20% goc duoi. Khung tren chu duoi hinh. Mau lay 46. Font Be Vietnam Pro (OFL). Overlay dung dung cau chot.
+
+## Handoff
+
+42 brief anh → 62 duyet. Neu len camp: 05 viet lai, khong paste cau nay vao primary text.

--- a/workflows/vi/content-engine.md
+++ b/workflows/vi/content-engine.md
@@ -63,7 +63,7 @@ GIAI DOAN 5 — DO LUONG (cuoi thang)
 
 ### Giai doan 2 — San xuat (hang ngay/tuan)
 
-**Skill:** `37-caption-social`, `04-script-video`, `05-copy-quang-cao`, `14-email-marketing`, `38-seeding-plan`, `06-brief-ugc-egc`
+**Skill:** `37-caption-social`, `04-script-video`, `05-copy-quang-cao`, `74-copy-hai-lop`, `14-email-marketing`, `38-seeding-plan`, `06-brief-ugc-egc`
 **Input:** Content brief tung bai + brand voice
 **Output:** Content san dang / san giao
 **Quy tac:** Moi output doi chieu brand voice truoc khi trinh duyet.


### PR DESCRIPTION
# PR: Them skill moi

## Skill
- **Ten:** `74-copy-hai-lop`
- **Category:** content
- **Version:** 1.0.0

## Mo ta

Slogan / headline poster / cau ngan **hai lop nghia** cho cluster VN: lop mat dung o hot/le/canh, lop trong la brand, mot nhip nhay. Ra 3-5 the khac cong thuc + brief visual giao `42`.

**Khong thay** `05-copy-quang-cao` (ads tra tien, pheu, policy) hay `37-caption-social` (caption organic dai). Method thich nghi tu MIT skill [crawfordxx/xiaoma-durex-copywriter](https://github.com/crawfordxx/xiaoma-durex-copywriter) (commit `d892bfb`). Khong nhap poster Durex/Reckitt, corpus cau goc, palette do hang, hay pipeline render.

## Frontmatter
```yaml
name: 74-copy-hai-lop
description: "Dung khi can viet slogan, headline poster hoac cau ngan co HAI LOP NGHIA..."
metadata:
  version: 1.0.0
  category: content
```

## Checklist

### Spec compliance
- [x] Chay `./validate-skills.sh` — Passed: 145 | Warnings: 0 | Issues: 0
  (145 = 144 marketplace + `73-video-ai-heygen` van untracked san tren cay local, khong nam trong PR nay)
- [x] SKILL.md 234 dong (< 500)
- [x] Frontmatter du: name, description (trigger phrases + sibling routing), metadata.version, category
- [x] Name trong frontmatter khop ten folder

### Noi dung
- [x] Doc context / brand voice truoc khi viet
- [x] Thu thap thong tin toi da 4 cau (mac dinh 0-1)
- [x] 8 cong thuc + 5 moc noi (bang)
- [x] Output template co cau truc
- [x] Cross-ref 05 / 37 / 42 / 58 / 35 / 62 / 66
- [x] Quality checklist + 11 bien gioi cung (IP + QC VN)
- [x] Vi du spa trong `references/vi-du-spa.md`

### Vietnam-first
- [x] Doi am / noi lai / tuc ngu lat — khong dich pun Trung
- [x] Vi du nganh VN (spa, F&B, SaaS/khoa)
- [x] Kenh mac dinh feed 4:5; handoff ads ve 05

### Housekeeping
- [x] `.claude-plugin/marketplace.json` + `plugin.json` (count 144; version van 3.7.0)
- [x] `VERSIONS.md` + `CHANGELOG.md`
- [x] `README.md` / `README.vi.md` / `docs/skill-map.md` / `docs/faq.md` / `ROADMAP.md`
- [x] Routing toi thieu tren `05` 2.5.2, `37` 1.0.2, `42` 1.0.2, `58` 1.0.2
- [x] `agents/content-producer.md` + `workflows/vi/content-engine.md`

## Related skills
Skill nay goi: `42-brief-hinh-anh`, `05-copy-quang-cao` (neu len camp), `37-caption-social` (neu can caption dai), `62-marketing-review`
Skill nay duoc goi boi: `05`, `37`, `42`, `58`, `content-producer`, `content-engine`

## Test
- [x] Validator repo: Issues 0
- [ ] Chua chay thu tren Claude Code / ChatGPT (cho reviewer / dung thu)

## Notes
- `CLAUDE.md` khong nam trong PR: file instruction bi chan ghi o session nay. Routing 74 da nam o README / workflow / agent.
- Khong commit `.agents/` hay `skills/vi/73-video-ai-heygen/` (dirty tree san, khong thuoc gói nay).
- File visual reference dat ten `khung-visual-hai-lop.md` vi `.gitignore` co rule `brief-*.md`.
- Public output cam nhac Durex/Reckitt nhu affiliation. Trigger `'an y nhu Durex'` chi de nhan intent.
- Cua so legal: so sanh doi thu, claim y te, consent nguoi that, 18+, hotspot thuong tam — human + `62` truoc dang. Khong phai tu van luat su.